### PR TITLE
Corrects logic to reflect changes in spec harness

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -30,12 +30,12 @@ class Item < ApplicationRecord
   end
 
   def best_day
-    Invoice.select("invoices.created_at AS best_day, SUM(invoice_items.quantity) as volume")
-           .joins(:items, :transactions)
+    Invoice.select("DATE_TRUNC('day', invoices.created_at) AS best_day, SUM(invoice_items.quantity) as volume")
+           .joins(:invoice_items, :transactions)
            .merge(Transaction.unscoped.successful)
            .where(invoice_items: {item_id: self.id})
-           .group(:created_at)
-           .order('volume desc, invoices.created_at desc').first
+           .group("best_day")
+           .order('volume desc, best_day desc').first
 
     # Invoice.select("invoices.created_at AS best_day, SUM(invoice_items.quantity) as total_quantity")
     #        .joins(:transactions)

--- a/app/serializers/best_day_serializer.rb
+++ b/app/serializers/best_day_serializer.rb
@@ -1,4 +1,6 @@
 class BestDaySerializer
   include FastJsonapi::ObjectSerializer
-  attributes :best_day
+  attribute :best_day do |resource|
+    resource.best_day.strftime("%F")
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -57,17 +57,16 @@ RSpec.describe Item, type: :model do
         @item = create(:item, merchant: @merchant)
         @two_weeks_ago = 2.weeks.ago.strftime("%F %T UTC")
         @yesterday = 1.day.ago.strftime("%F %T UTC")
-        @invoices = create_list(:invoice, 5, created_at: @two_weeks_ago, customer: @customer, merchant: @merchant)
+        @invoices = create_list(:invoice, 3, created_at: @two_weeks_ago, customer: @customer, merchant: @merchant)
         @invoices.each do |invoice|
           create(:transaction, invoice: invoice, created_at: @two_weeks_ago)
           create(:invoice_item, item: @item, invoice: invoice)
         end
-        # Adjusted to remove test for non-rolling 24 hour period
-        # @invoices = create_list(:invoice, 2, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"), customer: @customer, merchant: @merchant)
-        # @invoices.each do |invoice|
-        #   create(:transaction, invoice: invoice, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"))
-        #   create(:invoice_item, item: @item, invoice: invoice)
-        # end
+        @invoices = create_list(:invoice, 2, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"), customer: @customer, merchant: @merchant)
+        @invoices.each do |invoice|
+          create(:transaction, invoice: invoice, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"))
+          create(:invoice_item, item: @item, invoice: invoice)
+        end
         @invoices = create_list(:invoice, 3, invoice_items: [create(:invoice_item, item: @item)], created_at: @yesterday, customer: @customer, merchant: @merchant)
         @invoices.each do |invoice|
           create(:transaction, invoice: invoice, created_at: @yesterday)
@@ -76,7 +75,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'returns the day where the item was sold the most' do
-        expect(@item.best_day.best_day.strftime("%F %T UTC")).to eq(@two_weeks_ago)
+        expect(@item.best_day.best_day.strftime("%F")).to eq(2.weeks.ago.strftime("%F"))
       end
     end
   end

--- a/spec/requests/api/v1/items/item_request_spec.rb
+++ b/spec/requests/api/v1/items/item_request_spec.rb
@@ -260,19 +260,18 @@ describe 'Items API' do
         @merchant = create(:merchant)
         @item = create(:item, merchant: @merchant)
         @two_weeks_ago = 2.weeks.ago.strftime("%F %T UDT")
-        @response_time = 2.weeks.ago.strftime("%FT%T.000Z")
+        @response_time = 2.weeks.ago.strftime("%F")
         @yesterday = 1.day.ago.strftime("%F %T UDT")
-        @invoices = create_list(:invoice, 5, created_at: @two_weeks_ago, customer: @customer, merchant: @merchant)
+        @invoices = create_list(:invoice, 3, created_at: @two_weeks_ago, customer: @customer, merchant: @merchant)
         @invoices.each do |invoice|
           create(:transaction, invoice: invoice, created_at: @two_weeks_ago)
           create(:invoice_item, item: @item, invoice: invoice)
         end
-        # Adjusted to not use rolling 24 hour period per discussion with Josh
-        # @invoices = create_list(:invoice, 2, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"), customer: @customer, merchant: @merchant)
-        # @invoices.each do |invoice|
-        #   create(:transaction, invoice: invoice, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"))
-        #   create(:invoice_item, item: @item, invoice: invoice)
-        # end
+        @invoices = create_list(:invoice, 2, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"), customer: @customer, merchant: @merchant)
+        @invoices.each do |invoice|
+          create(:transaction, invoice: invoice, created_at: (2.weeks.ago + 3.hours).strftime("%F %T UTC"))
+          create(:invoice_item, item: @item, invoice: invoice)
+        end
         @invoices = create_list(:invoice, 3, invoice_items: [create(:invoice_item, item: @item)], created_at: @yesterday, customer: @customer, merchant: @merchant)
         @invoices.each do |invoice|
           create(:transaction, invoice: invoice, created_at: @yesterday)


### PR DESCRIPTION
Updates item#best_day method to return a single calendar date in place of a rolling 24 hour maximum following update to project spec.